### PR TITLE
[add] filter of importable orders by state

### DIFF
--- a/connector_prestashop/__openerp__.py
+++ b/connector_prestashop/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "PrestaShop-Odoo connector",
-    "version": "9.0.1.0.3",
+    "version": "9.0.1.0.4",
     "license": "AGPL-3",
     "depends": [
         "account",

--- a/connector_prestashop/models/prestashop_backend/common.py
+++ b/connector_prestashop/models/prestashop_backend/common.py
@@ -115,6 +115,11 @@ class PrestashopBackend(models.Model):
         required=True,
         string='Shipping Product',
     )
+    importable_order_state_ids = fields.Many2many(
+        comodel_name='sale.order.state',
+        string='Importable sale order states',
+        help="If valued only orders matching these states will be imported.",
+    )
 
     @api.model
     def _default_pricelist_id(self):

--- a/connector_prestashop/views/prestashop_model_view.xml
+++ b/connector_prestashop/views/prestashop_model_view.xml
@@ -51,6 +51,7 @@
                     <field name="taxes_included"/>
                     <field name="discount_product_id" />
                     <field name="shipping_product_id" />
+                    <field name="importable_order_state_ids" widget="many2many_tags" />
                 </group>
                 <notebook>
                     <page name="import" string="Imports">


### PR DESCRIPTION
If `backend_record.importable_order_state_ids` is valued
we check if current order is in the list.
If not, the job fails gracefully.

TODO: add tests.