### PR TITLE
8.0 [FIX] connector prestashop minor fixes

### DIFF
--- a/connector_prestashop/models/product_product/common.py
+++ b/connector_prestashop/models/product_product/common.py
@@ -89,15 +89,14 @@ class ProductProduct(models.Model):
     @api.multi
     def update_prestashop_qty(self):
         for product in self:
-            if product.product_variant_count > 1:
+            if product.product_variant_count == 1:
+                # Recompute qty in template binding if product has not
+                # combinations
+                product.product_tmpl_id.update_prestashop_quantities()
+            elif product.product_variant_count > 1:
                 # Recompute qty in combination binding
                 for combination_binding in product.prestashop_bind_ids:
                     combination_binding.recompute_prestashop_qty()
-            # Recompute qty in product template binding if any combination
-            # if modified
-            for prestashop_product in \
-                    product.product_tmpl_id.prestashop_bind_ids:
-                prestashop_product.recompute_prestashop_qty()
 
     @api.multi
     def update_prestashop_quantities(self):

--- a/connector_prestashop_catalog_manager/product.py
+++ b/connector_prestashop_catalog_manager/product.py
@@ -253,7 +253,9 @@ class ProductTemplateExport(TranslationPrestashopExporter):
 
     def export_variants(self):
         combination_obj = self.session.env['prestashop.product.combination']
-        for product in self.erp_record.product_variant_ids:
+        for index, product in enumerate(
+                self.erp_record.product_variant_ids.sorted(
+                    key=lambda r: r.default_on)):
             if not product.attribute_value_ids:
                 continue
             combination_ext_id = combination_obj.search([
@@ -273,7 +275,8 @@ class ProductTemplateExport(TranslationPrestashopExporter):
                 self.session,
                 'prestashop.product.combination',
                 combination_ext_id.id, priority=50,
-                eta=timedelta(seconds=20))
+                eta=timedelta(seconds=10 + (index * 2))
+            )
 
     def _not_in_variant_images(self, image):
         images = []


### PR DESCRIPTION
[8.0][FIX] connector_prestashop: Recompute qty in product template if product has not variants. This provoke extra writes.

[8.0][FIX] connector_prestashop_catalog_manager: Update always the default variant in las position. In recent ps versions set tow variants as default is forbidden

cc @Tecnativa