### PR TITLE
[9.0][IMP] account tax view

### DIFF
--- a/connector_prestashop/views/account_view.xml
+++ b/connector_prestashop/views/account_view.xml
@@ -31,7 +31,7 @@
         <field name="arch" type="xml">
             <form string="Account Tax Group">
                 <field name="name" colspan="4"/>
-                <field name="tax_ids" colspan="4"/>
+                <field name="tax_ids" colspan="4" widget="many2many"/>
                 <group string="PrestaShop Binding">
                     <field name="prestashop_bind_ids"
                            nolabel="1"/>


### PR DESCRIPTION
On configuration process, when you set tax relation, on account.tax.group you can not set created taxes.

As a quick fix I only update view, to use many2many widget, but I think that it would be better to change this field from many2one to many2many field.

What do you think?