### PR TITLE
[fix] allow user to read prestashop.product.category

### DIFF
--- a/connector_prestashop/security/ir.model.access.csv
+++ b/connector_prestashop/security/ir.model.access.csv
@@ -24,6 +24,7 @@ access_prestashop_sale_order_line_discount_user,User access on prestashop.sale.o
 access_prestashop_sale_order_line_discount_full,Full access on prestashop.sale.order.line.discount,model_prestashop_sale_order_line_discount,connector.group_connector_manager,1,1,1,1
 access_prestashop_delivery_carrier_full,Full access on prestashop.delivery.carrier,model_prestashop_delivery_carrier,connector.group_connector_manager,1,1,1,1
 access_prestashop_product_category_full,Full access on prestashop.product.category,model_prestashop_product_category,connector.group_connector_manager,1,1,1,1
+access_prestashop_product_category_user,User access on prestashop.product.category,model_prestashop_product_category,base.group_user,1,0,0,0
 access_prestashop_product_image_full,Full access on prestashop.product.image,model_prestashop_product_image,connector.group_connector_manager,1,1,1,1
 access_prestashop_product_template_user,User access on prestashop.product.template,model_prestashop_product_template,base.group_user,1,0,0,0
 access_prestashop_product_template,Full access on prestashop.product.template,model_prestashop_product_template,connector.group_connector_manager,1,1,1,1

--- a/connector_prestashop/views/product_category_view.xml
+++ b/connector_prestashop/views/product_category_view.xml
@@ -45,7 +45,7 @@
         <field name="inherit_id" ref="product.product_category_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='first']" position="after">
-                <group string="PrestaShop Binding">
+                <group string="PrestaShop Binding" groups="connector.group_connector_manager">
                     <field name="prestashop_bind_ids"
                            nolabel="1"/>
                 </group>


### PR DESCRIPTION
**Current behavior**

* you are an inventory manager
* you go to "Product categories"
* you open a category
* KABOOM! No access to prestashop.product.category

**Desired behavior**

* no error pls!
* hide bindings if not connector manager group

NOTE: there are other views/models where we allow ppl to read records but maybe it would be better to hide connector bindings as I did here.