### PR TITLE
[fix] combination image: do not default to `False` when missing

### DIFF
--- a/connector_prestashop_catalog_manager/models/product_product/exporter.py
+++ b/connector_prestashop_catalog_manager/models/product_product/exporter.py
@@ -167,8 +167,12 @@ class ProductCombinationExportMapper(TranslationPrestashopExportMapper):
             ('product_option_values',
                 {'product_option_value':
                  self._get_product_option_value(record)}),
-            ('images', {'image': self._get_combination_image(record) or False})
         ])
+        image = self._get_combination_image(record)
+        if image:
+            associations['images'] = {
+                'image': self._get_combination_image(record)
+            }
         return {'associations': associations}
 
 


### PR DESCRIPTION
from v 1.6.1.11 PS gets crazy if you pass something that is not an array.
Passing `images` is not required so it's even better to not include it if we don't put any value into it.