### PR TITLE
Fix export when no location has flag prestashop_synchronized

### DIFF
--- a/connector_prestashop/__openerp__.py
+++ b/connector_prestashop/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "PrestaShop-Odoo connector",
-    "version": "9.0.1.0.4",
+    "version": "9.0.1.0.5",
     "license": "AGPL-3",
     "depends": [
         "account",

--- a/connector_prestashop/models/prestashop_backend/common.py
+++ b/connector_prestashop/models/prestashop_backend/common.py
@@ -302,6 +302,32 @@ class PrestashopBackend(models.Model):
         import_record(session, model_name, self.id, ext_id)
         return True
 
+    @api.multi
+    def _get_locations_for_stock_quantities(self):
+        root_location = (self.stock_location_id or
+                         self.warehouse_id.lot_stock_id)
+        locations = self.env['stock.location'].search([
+            ('id', 'child_of', root_location.id),
+            ('prestashop_synchronized', '=', True),
+            ('usage', '=', 'internal'),
+        ])
+        # if we choosed a location but none where flagged
+        # 'prestashop_synchronized', consider we want all of them in the tree
+        if not locations:
+            locations = self.env['stock.location'].search([
+                ('id', 'child_of', root_location.id),
+                ('usage', '=', 'internal'),
+            ])
+        if not locations:
+            # we must not pass an empty location or we would have the
+            # stock for every warehouse, which is the last thing we
+            # expect
+            raise exceptions.UserError(
+                _('No internal location found to compute the product '
+                  'quantity.')
+            )
+        return locations
+
 
 class PrestashopShopGroup(models.Model):
     _name = 'prestashop.shop.group'

--- a/connector_prestashop/models/product_product/common.py
+++ b/connector_prestashop/models/product_product/common.py
@@ -164,11 +164,12 @@ class PrestashopProductCombination(models.Model):
     @api.multi
     def recompute_prestashop_qty(self):
         # group products by backend
-        backends = defaultdict(self.browse)
+        backends = defaultdict(set)
         for product in self:
-            backends[product.backend_id] |= product
+            backends[product.backend_id].add(product.id)
 
-        for backend, products in backends.iteritems():
+        for backend, product_ids in backends.iteritems():
+            products = self.browse(product_ids)
             products._recompute_prestashop_qty_backend(backend)
         return True
 

--- a/connector_prestashop/models/product_template/common.py
+++ b/connector_prestashop/models/product_template/common.py
@@ -3,7 +3,7 @@
 
 from collections import defaultdict
 
-from openerp import _, exceptions, api, fields, models
+from openerp import api, fields, models
 from openerp.addons.decimal_precision import decimal_precision as dp
 
 from ...unit.backend_adapter import GenericAdapter
@@ -111,8 +111,6 @@ class PrestashopProductTemplate(models.Model):
         digits_compute=dp.get_precision('Product Price'),
     )
 
-    RECOMPUTE_QTY_STEP = 1000
-
     @api.multi
     def recompute_prestashop_qty(self):
         # group products by backend
@@ -126,28 +124,7 @@ class PrestashopProductTemplate(models.Model):
 
     @api.multi
     def _recompute_prestashop_qty_backend(self, backend):
-        root_location = (backend.stock_location_id or
-                         backend.warehouse_id.lot_stock_id)
-        locations = self.env['stock.location'].search([
-            ('id', 'child_of', root_location.id),
-            ('prestashop_synchronized', '=', True),
-            ('usage', '=', 'internal'),
-        ])
-        # if we choosed a location but none where flagged
-        # 'prestashop_synchronized', consider we want all of them in the tree
-        if not locations:
-            locations = self.env['stock.location'].search([
-                ('id', 'child_of', root_location.id),
-                ('usage', '=', 'internal'),
-            ])
-        if not locations:
-            # we must not pass an empty location or we would have the
-            # stock for every warehouse, which is the last thing we
-            # expect
-            raise exceptions.UserError(
-                _('No internal location found to compute the product '
-                  'quantity.')
-            )
+        locations = backend._get_locations_for_stock_quantities()
         self_loc = self.with_context(location=locations.ids,
                                      compute_child=False)
         for product in self_loc:

--- a/connector_prestashop/models/product_template/common.py
+++ b/connector_prestashop/models/product_template/common.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from openerp import api, fields, models
+from openerp import _, exceptions, api, fields, models
 from openerp.addons.decimal_precision import decimal_precision as dp
 
 from ...unit.backend_adapter import GenericAdapter
@@ -118,11 +118,28 @@ class PrestashopProductTemplate(models.Model):
         return True
 
     def _prestashop_qty(self):
+        root_location = (self.backend_id.stock_location_id or
+                         self.backend_id.warehouse_id.lot_stock_id)
         locations = self.env['stock.location'].search([
-            ('id', 'child_of', self.backend_id.warehouse_id.lot_stock_id.id),
+            ('id', 'child_of', root_location.id),
             ('prestashop_synchronized', '=', True),
             ('usage', '=', 'internal'),
         ])
+        # if we choosed a location but none where flagged
+        # 'prestashop_synchronized', consider we want all of them in the tree
+        if not locations:
+            locations = self.env['stock.location'].search([
+                ('id', 'child_of', root_location.id),
+                ('usage', '=', 'internal'),
+            ])
+        if not locations:
+            # we must not pass an empty location or we would have the
+            # stock for every warehouse, which is the last thing we
+            # expect
+            raise exceptions.UserError(
+                _('No internal location found to compute the product '
+                  'quantity.')
+            )
         return self.with_context(location=locations.ids).qty_available
 
 

--- a/connector_prestashop/models/product_template/common.py
+++ b/connector_prestashop/models/product_template/common.py
@@ -140,7 +140,8 @@ class PrestashopProductTemplate(models.Model):
                 _('No internal location found to compute the product '
                   'quantity.')
             )
-        return self.with_context(location=locations.ids).qty_available
+        self_c = self.with_context(location=locations.ids, compute_child=False)
+        return self_c.qty_available
 
 
 @prestashop

--- a/connector_prestashop/models/product_template/common.py
+++ b/connector_prestashop/models/product_template/common.py
@@ -114,11 +114,12 @@ class PrestashopProductTemplate(models.Model):
     @api.multi
     def recompute_prestashop_qty(self):
         # group products by backend
-        backends = defaultdict(self.browse)
+        backends = defaultdict(set)
         for product in self:
-            backends[product.backend_id] |= product
+            backends[product.backend_id].add(product.id)
 
-        for backend, products in backends.iteritems():
+        for backend, product_ids in backends.iteritems():
+            products = self.browse(product_ids)
             products._recompute_prestashop_qty_backend(backend)
         return True
 


### PR DESCRIPTION
When there is no location with the flag prestashop_synchronized in the
location tree,

Current behavior:

The `location` key in the context is empty then the qty_available is
computed for *every* locations/warehouses.

Expected behavior:

If there is at least one location flagged, use it, otherwise, use all
the locations of the tree, starting from the selected location or
selected warehouse location.

When no location can be found (for instance because user selected a
location with a usage different than 'internal'), then it should just
fail and not return the stock of all warehouses.

Being able to synchronize without activating 'prestashop_synchronized'
is important: when used, this feature will trigger an export every time
a quant is changed or created, on a large catalog, we might prefer only
using the cron to have less frequent updates and less jobs.

A second fix is that when a stock_location_id is set on the backend, it
should be used, it was only used for the import of stock.