### PR TITLE
Add field prestashop_image_to_url control in backend

### DIFF
--- a/connector_prestashop_catalog_manager/__init__.py
+++ b/connector_prestashop_catalog_manager/__init__.py
@@ -8,3 +8,6 @@ from . import product_attribute
 from . import product_combination
 from . import wizard
 from . import product_image
+from . import models
+
+

--- a/connector_prestashop_catalog_manager/__openerp__.py
+++ b/connector_prestashop_catalog_manager/__openerp__.py
@@ -26,6 +26,8 @@
         'wizard/sync_products_view.xml',
         'wizard/active_deactive_products_view.xml',
         'views/product_image_view.xml',
+        'views/prestashop_backend_view.xml',
+
     ],
     "installable": True,
 }

--- a/connector_prestashop_catalog_manager/models/__init__.py
+++ b/connector_prestashop_catalog_manager/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import prestashop_backend

--- a/connector_prestashop_catalog_manager/models/prestashop_backend/__init__.py
+++ b/connector_prestashop_catalog_manager/models/prestashop_backend/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import common

--- a/connector_prestashop_catalog_manager/models/prestashop_backend/common.py
+++ b/connector_prestashop_catalog_manager/models/prestashop_backend/common.py
@@ -9,6 +9,7 @@ class PrestashopBackend(models.Model):
 
     prestashop_image_to_url = fields.Boolean(
         string="PrestaShop Image Storage Url",
-        help="If this field is checked, PrestaShop images are loaded by url instead Database",
+        help="If this field is checked, PrestaShop images are loaded by url"
+             "instead Database",
         default=True
     )

--- a/connector_prestashop_catalog_manager/models/prestashop_backend/common.py
+++ b/connector_prestashop_catalog_manager/models/prestashop_backend/common.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import fields, models
+
+
+class PrestashopBackend(models.Model):
+    _inherit = 'prestashop.backend'
+
+    prestashop_image_to_url = fields.Boolean(
+        string="PrestaShop Image Storage Url",
+        help="If this field is checked, PrestaShop images are loaded by url instead Database",
+        default=True
+    )

--- a/connector_prestashop_catalog_manager/product_image.py
+++ b/connector_prestashop_catalog_manager/product_image.py
@@ -115,7 +115,8 @@ class ProductImageExport(PrestashopExporter):
             self._validate_data(record)
             self.prestashop_id = self._create(record)
             self._after_export()
-        self._link_image_to_url()
+        if self.backend_record.prestashop_image_to_url:
+            self._link_image_to_url()
         message = _('Record exported with ID %s on Prestashop.')
         return message % self.prestashop_id
 

--- a/connector_prestashop_catalog_manager/views/prestashop_backend_view.xml
+++ b/connector_prestashop_catalog_manager/views/prestashop_backend_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_prestashop_backend_form_inherit" model="ir.ui.view">
+            <field name="name">prestashop.backend.form.inherit</field>
+            <field name="model">prestashop.backend</field>
+            <field name="inherit_id" ref="connector_prestashop.view_prestashop_backend_form"/>
+            <field name="arch" type="xml">
+                <field name="shipping_product_id" position="after">
+                    <field name="prestashop_image_to_url"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This PR  add Boolean field in prestashop.backend model.
This field allow specify the way to storage a prestashop image (url or database).
Default a prestashop image is stored as url only.
