### PR TITLE
8.0 - Fix import product translations

### DIFF
--- a/connector_prestashop/models/product_template/importer.py
+++ b/connector_prestashop/models/product_template/importer.py
@@ -366,6 +366,7 @@ class TemplateRecordImport(TranslatableRecordImporter):
     }
 
     def _after_import(self, erp_id):
+        super(TemplateRecordImport, self)._after_import(erp_id)
         self.import_images(erp_id)
         self.import_combinations()
         self.attribute_line(erp_id)


### PR DESCRIPTION
Call super in product_template _after_import to import product translations.