### PR TITLE
8.0-ADD mapping for categ_id field in product.combination

### DIFF
--- a/connector_prestashop/models/product_product/importer.py
+++ b/connector_prestashop/models/product_product/importer.py
@@ -228,6 +228,13 @@ class ProductCombinationMapper(ImportMapper):
             return {'ean13': record['ean13']}
         return {}
 
+    @mapping
+    def categ_id(self, record):
+        template = self.binder_for('prestashop.product.template').to_odoo(
+            record['id_product'], unwrap=True)
+        if template and template.categ_id:
+            return {'categ_id': template.categ_id.id}
+
     def _get_tax_ids(self, record):
         product_tmpl_binder = self.unit_for(
             GenericAdapter, 'prestashop.product.template')


### PR DESCRIPTION
This PR adds mapping for  categ_id  field in prestashop.product.combination ( when a product has combinations).