### PR TITLE
[fix] add missing `base_vat` dependency

### DIFF
--- a/connector_prestashop/__openerp__.py
+++ b/connector_prestashop/__openerp__.py
@@ -11,6 +11,7 @@
     "license": "AGPL-3",
     "depends": [
         "account",
+        "base_vat",  # for vat validation on partner address
         "product",
         "product_multi_category",  # oca/product-attribute
         "connector_ecommerce",  # oca/connector-ecommerce


### PR DESCRIPTION
Partner address importer relies on `simple_vat_check`
to validate VAT and drop a checkpoint if needed.
The feature comes from `base_vat` which could be
not installed (most localizations requires it, not all).

Prevents:
```
  File "[...]/connector-prestashop/connector_prestashop/models/res_partner/importer.py", line 205, in _check_vat
    return partner_model.simple_vat_check(vat_country, vat_number)
AttributeError: 'res.partner' object has no attribute 'simple_vat_check'
```