### PR TITLE
Fix path to id

### DIFF
--- a/connector_prestashop_catalog_manager/__openerp__.py
+++ b/connector_prestashop_catalog_manager/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Prestashop-Odoo Catalog Manager",
-    "version": "9.0.1.0.3",
+    "version": "9.0.1.0.4",
     "license": "AGPL-3",
     "depends": [
         "connector_prestashop"

--- a/connector_prestashop_catalog_manager/models/product_product/exporter.py
+++ b/connector_prestashop_catalog_manager/models/product_product/exporter.py
@@ -75,13 +75,14 @@ class ProductCombinationExport(TranslationPrestashopExporter):
                 )
             value_ext_id = option_binder.to_backend(value.id, wrap=True)
             if not value_ext_id:
-                value_ext_id = self.session.env[
+                value_binding = self.session.env[
                     'prestashop.product.combination.option.value']\
                     .with_context(connector_no_export=True).create({
                         'backend_id': self.backend_record.id,
-                        'odoo_id': value.val_id.id,
+                        'odoo_id': value.id,
                         'id_attribute_group': attribute_ext_id
                     })
+                value_ext_id = value_binding.id
                 export_record(
                     self.session,
                     'prestashop.product.combination.option.value',


### PR DESCRIPTION
'value' is a product.attribute.value, which is the type of record
expected in 'odoo_id', so there is no such thing as 'val_id'