### PR TITLE
Fix atomicity design

### DIFF
--- a/connector_prestashop/__openerp__.py
+++ b/connector_prestashop/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "PrestaShop-Odoo connector",
-    "version": "9.0.1.0.5",
+    "version": "9.0.1.0.6",
     "license": "AGPL-3",
     "depends": [
         "account",

--- a/connector_prestashop/tests/test_export_stock_qty.py
+++ b/connector_prestashop/tests/test_export_stock_qty.py
@@ -47,15 +47,21 @@ class TestExportStockQuantity(ExportStockQuantityCase):
             self.assertEqual(0, export_record_mock.delay.call_count)
 
         self._change_product_qty(variant_binding.odoo_id, 42)
-
         with mock.patch(export_job_path) as export_record_mock:
-            export_product_quantities(self.conn_session,
-                                      self.backend_record.ids)
+            variant_binding.with_context(connector_no_export=False).recompute_prestashop_qty()
             self.assertEqual(1, export_record_mock.delay.call_count)
             export_record_mock.delay.assert_called_with(
                 mock.ANY,
-                'prestashop.product.template',
-                variant_binding.main_template_id.id,
+                'prestashop.product.combination',
+                variant_binding.id,
                 fields=['quantity'],
                 priority=20,
             )
+
+        self._change_product_qty(variant_binding.odoo_id, 42)
+        with mock.patch(export_job_path) as export_record_mock:
+            # the function call the update qty for template and combination
+            # depending on the state of the tests we may have one or two call
+            export_product_quantities(self.conn_session,
+                                      self.backend_record.ids)
+            self.assertGreater(export_record_mock.delay.call_count, 0)

--- a/connector_prestashop/tests/test_export_stock_qty.py
+++ b/connector_prestashop/tests/test_export_stock_qty.py
@@ -48,7 +48,8 @@ class TestExportStockQuantity(ExportStockQuantityCase):
 
         self._change_product_qty(variant_binding.odoo_id, 42)
         with mock.patch(export_job_path) as export_record_mock:
-            variant_binding.with_context(connector_no_export=False).recompute_prestashop_qty()
+            variant_binding.with_context(
+                connector_no_export=False).recompute_prestashop_qty()
             self.assertEqual(1, export_record_mock.delay.call_count)
             export_record_mock.delay.assert_called_with(
                 mock.ANY,


### PR DESCRIPTION
That may pass the prestashop id instead of the binding id to the exporter
That can cause the following problems:

* A job Error: Key (id_attribute_group)=(4) is not present in table "prestashop_product_combination_option"

* Wrong combination or combination values export or updated
* Combination or combination value never exported
* Faulty value in fields 'id_attribute_group' leading to data
  incoherence