### PR TITLE
Add verbose and debug options

### DIFF
--- a/connector_prestashop/models/prestashop_backend/common.py
+++ b/connector_prestashop/models/prestashop_backend/common.py
@@ -120,6 +120,8 @@ class PrestashopBackend(models.Model):
         string='Importable sale order states',
         help="If valued only orders matching these states will be imported.",
     )
+    verbose = fields.Boolean(help="Output requests details in the logs")
+    debug = fields.Boolean(help="Activate PrestaShop's webservice debug mode")
 
     @api.model
     def _default_pricelist_id(self):

--- a/connector_prestashop/unit/backend_adapter.py
+++ b/connector_prestashop/unit/backend_adapter.py
@@ -114,6 +114,8 @@ class PrestaShopCRUDAdapter(CRUDAdapter):
         self.client = PrestaShopWebServiceDict(
             self.prestashop.api_url,
             self.prestashop.webservice_key,
+            debug=self.backend_record.debug,
+            verbose=self.backend_record.verbose,
         )
 
     def search(self, filters=None):

--- a/connector_prestashop/views/prestashop_model_view.xml
+++ b/connector_prestashop/views/prestashop_model_view.xml
@@ -41,6 +41,8 @@
                 <group col="4">
                     <field name="location" colspan="4"/>
                     <field name="webservice_key" colspan="4"/>
+                    <field name="verbose"/>
+                    <field name="debug"/>
                 </group>
                 <group name="main_configuration" string="Main Configuration">
                     <field name="pricelist_id"/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 html2text
-prestapyt >= 0.7.0
+prestapyt >= 0.9.0
 unidecode
 bs4
 # tests dependencies


### PR DESCRIPTION
Debug: activate the PrestaShop Webservice's debug option
Verbose: output in the logs the requests headers and data and response
headers
The log handler for "requests.packages.urllib3" must be set to DEBUG for
the verbose option.

Require to upgrade to prestapyt >= 0.9.0!