### PR TITLE
[9.0] [FIX] catalog_manager: Fix manufacturer export

### DIFF
--- a/connector_prestashop/unit/exporter.py
+++ b/connector_prestashop/unit/exporter.py
@@ -315,12 +315,7 @@ class PrestashopExporter(PrestashopBaseExporter):
 
 class TranslationPrestashopExporter(PrestashopExporter):
 
-    @property
-    def mapper(self):
-        if self._mapper is None:
-            self._mapper = self.connector_env.get_connector_unit(
-                TranslationPrestashopExportMapper)
-        return self._mapper
+    _base_mapper = TranslationPrestashopExportMapper
 
 
 def related_action_record(session, job):

--- a/connector_prestashop_catalog_manager/consumer.py
+++ b/connector_prestashop_catalog_manager/consumer.py
@@ -49,6 +49,15 @@ CATEGORY_EXPORT_FIELDS = [
 
 EXCLUDE_FIELDS = ['list_price']
 
+EXCLUDE_TEMPLATE_IMAGE_FIELDS = [
+    'image',
+    'image_medium',
+    'image_small',
+    'image_main',
+    'image_main_medium',
+    'image_main_small',
+]
+
 
 @on_record_create(model_names='prestashop.product.category')
 def prestashop_product_category_create(session, model_name, record_id, fields):
@@ -154,11 +163,12 @@ def product_template_write(session, model_name, record_id, fields):
         return
     model = session.env[model_name]
     record = model.browse(record_id)
-    for binding in record.prestashop_bind_ids:
-        export_record.delay(
-            session, 'prestashop.product.template', binding.id, fields,
-            priority=20,
-        )
+    if set(fields.keys()) - set(EXCLUDE_TEMPLATE_IMAGE_FIELDS):
+        for binding in record.prestashop_bind_ids:
+            export_record.delay(
+                session, 'prestashop.product.template', binding.id, fields,
+                priority=20,
+            )
 
 
 @on_record_create(model_names='prestashop.product.combination')

--- a/connector_prestashop_catalog_manager/models/product_template/exporter.py
+++ b/connector_prestashop_catalog_manager/models/product_template/exporter.py
@@ -152,7 +152,6 @@ class ProductTemplateExporter(TranslationPrestashopExporter):
     def _update(self, data):
         """ Update an Prestashop record """
         assert self.prestashop_id
-        self.export_variants()
         self.check_images()
         self.backend_adapter.write(self.prestashop_id, data)
 

--- a/connector_prestashop_manufacturer/README.rst
+++ b/connector_prestashop_manufacturer/README.rst
@@ -44,8 +44,7 @@ Credits
 Images
 ------
 
-* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools
-/blob/master/template/module/static/description/icon.svg>`_.
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------

--- a/connector_prestashop_manufacturer/__openerp__.py
+++ b/connector_prestashop_manufacturer/__openerp__.py
@@ -8,7 +8,7 @@
     'category': 'Connector',
     'website': 'https://odoo-community.org/',
     'author': 'Tecnativa, '
-              'Camptocamp SA '
+              'Camptocamp SA, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'application': False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ unidecode
 bs4
 # tests dependencies
 freezegun
-vcrpy
+vcrpy==1.10.5


### PR DESCRIPTION
Hi,

This closes #90 , corrects the following error when a product is exported:

> AssertionError: Several classes found for <class 'openerp.addons.connector_prestashop.unit.mapper.TranslationPrestashopExportMapper'> with session <Session db_name: db_prod, uid: 7, context: {'job_uuid': u'0e6fd3d8-d852-444a-8d11-ce8270249d05'}>, model name: prestashop.product.template. Found: set([<class 'openerp.addons.connector_prestashop_catalog_manager.models.product_template.exporter.ProductTemplateExportMapper'>, <class 'openerp.addons.connector_prestashop_catalog_manager.models.product_template.exporter.ManufacturerExportMapper'>])

The problem was that more than one `ExportMapper` were defined for `prestashop.product.template`. It has been solved specifying `ProductTemplateExportMapper` as the right mapper.

There are many changes because it has been necessary relocate class `ProductTemplateExportMapper`.

I remain at your disposal for any question.

Thanks!

cc @PlanetaTIC