### PR TITLE
[10.0] [FIX] connector_prestashop: Fix resync

### DIFF
--- a/connector_prestashop/models/binding/common.py
+++ b/connector_prestashop/models/binding/common.py
@@ -3,7 +3,6 @@
 
 from odoo import models, fields, api
 from odoo.addons.queue_job.job import job, related_action
-from ...components.importer import import_record
 from odoo.addons.connector.exception import RetryableJobError
 
 
@@ -80,12 +79,11 @@ class PrestashopBinding(models.AbstractModel):
     # TODO: Research
     @api.multi
     def resync(self):
-        func = import_record
+        func = self.import_record
         if self.env.context.get('connector_delay'):
-            func = import_record.delay
+            func = self.import_record.delay
         for record in self:
-            func(self.env, self._name, record.backend_id.id,
-                 record.prestashop_id)
+            func(record.backend_id, record.prestashop_id)
         return True
 
 


### PR DESCRIPTION
Hi,

This fixes resync error:

![resync](https://user-images.githubusercontent.com/39995504/49238933-d45fe880-f401-11e8-9f07-1f2b03ca8d52.png)

```
  File "/.../connector_prestashop/models/binding/common.py", line 88, in resync
    record.prestashop_id)
TypeError: import_record() takes no arguments (4 given)
```

Regards!
