### PR TITLE
[10.0] [FIX] connector_prestashop: Fix online tests (fresh Prestashop available)

### DIFF
--- a/connector_prestashop/tests/fixtures/cassettes/test_export_stock_quantity.yaml
+++ b/connector_prestashop/tests/fixtures/cassettes/test_export_stock_quantity.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.6.0 CPython/2.7.9 Linux/4.4.0-51-generic]
     method: GET
-    uri: http://172.22.0.4/api/stock_availables?filter%5Bid_product_attribute%5D=0&filter%5Bid_product%5D=1
+    uri: http://172.22.0.4/api/stock_availables?filter%5Bid_product_attribute%5D=0&filter%5Bid_product%5D=2
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
@@ -15,7 +15,7 @@ interactions:
 
         <stock_availables>
 
-        <stock_available id="1" xlink:href="http://172.22.0.4/api/stock_availables/1"/>
+        <stock_available id="2" xlink:href="http://172.22.0.4/api/stock_availables/2"/>
 
         </stock_availables>
 
@@ -47,12 +47,12 @@ interactions:
       Cookie: [PrestaShop-095ca4fa56f569ddf56f692e2249251a=DYHr6QQHnOuI4%2BKs9hL5TefxaDQeKRvH4iskMptWR8Ao0kKwTQ%2BHn74qCsABs2oIgh1NPrPv59GgeUjPVxKZOHRsmUHT3M%2BW%2FfrbuB4NBJU%3D000078]
       User-Agent: [python-requests/2.6.0 CPython/2.7.9 Linux/4.4.0-51-generic]
     method: GET
-    uri: http://172.22.0.4/api/stock_availables/1
+    uri: http://172.22.0.4/api/stock_availables/2
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
         <prestashop xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<stock_available>\n\
-        \t<id><![CDATA[1]]></id>\n\t<id_product xlink:href=\"http://172.22.0.4/api/products/1\"\
-        ><![CDATA[1]]></id_product>\n\t<id_product_attribute><![CDATA[0]]></id_product_attribute>\n\
+        \t<id><![CDATA[2]]></id>\n\t<id_product xlink:href=\"http://172.22.0.4/api/products/2\"\
+        ><![CDATA[2]]></id_product>\n\t<id_product_attribute><![CDATA[0]]></id_product_attribute>\n\
         \t<id_shop xlink:href=\"http://172.22.0.4/api/shops/1\"><![CDATA[1]]></id_shop>\n\
         \t<id_shop_group><![CDATA[0]]></id_shop_group>\n\t<quantity><![CDATA[1799]]></quantity>\n\
         \t<depends_on_stock><![CDATA[0]]></depends_on_stock>\n\t<out_of_stock><![CDATA[2]]></out_of_stock>\n\
@@ -72,7 +72,7 @@ interactions:
       x-powered-by: [PrestaShop Webservice]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?><prestashop><stock_available><id_product_attribute>0</id_product_attribute><id_product>1</id_product><out_of_stock>2</out_of_stock><id_shop>1</id_shop><quantity>0</quantity><depends_on_stock>0</depends_on_stock><id>1</id><id_shop_group>0</id_shop_group></stock_available></prestashop>'
+    body: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?><prestashop><stock_available><id_product_attribute>0</id_product_attribute><id_product>2</id_product><out_of_stock>0</out_of_stock><id_shop>1</id_shop><quantity>0</quantity><depends_on_stock>0</depends_on_stock><id>2</id><id_shop_group>0</id_shop_group></stock_available></prestashop>'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -86,11 +86,11 @@ interactions:
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
         <prestashop xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<stock_available>\n\
-        \t<id><![CDATA[1]]></id>\n\t<id_product xlink:href=\"http://172.22.0.4/api/products/1\"\
-        ><![CDATA[1]]></id_product>\n\t<id_product_attribute><![CDATA[0]]></id_product_attribute>\n\
+        \t<id><![CDATA[2]]></id>\n\t<id_product xlink:href=\"http://172.22.0.4/api/products/2\"\
+        ><![CDATA[2]]></id_product>\n\t<id_product_attribute><![CDATA[0]]></id_product_attribute>\n\
         \t<id_shop xlink:href=\"http://172.22.0.4/api/shops/1\"><![CDATA[1]]></id_shop>\n\
         \t<id_shop_group><![CDATA[0]]></id_shop_group>\n\t<quantity><![CDATA[0]]></quantity>\n\
-        \t<depends_on_stock><![CDATA[0]]></depends_on_stock>\n\t<out_of_stock><![CDATA[2]]></out_of_stock>\n\
+        \t<depends_on_stock><![CDATA[0]]></depends_on_stock>\n\t<out_of_stock><![CDATA[0]]></out_of_stock>\n\
         </stock_available>\n</prestashop>\n"}
     headers:
       access-time: ['1481297840']

--- a/connector_prestashop/tests/fixtures/cassettes/test_import_partner_address_record_1.yaml
+++ b/connector_prestashop/tests/fixtures/cassettes/test_import_partner_address_record_1.yaml
@@ -15,7 +15,7 @@ interactions:
         \t<id_manufacturer><![CDATA[0]]></id_manufacturer>\n\t<id_supplier><![CDATA[0]]></id_supplier>\n\
         \t<id_warehouse><![CDATA[0]]></id_warehouse>\n\t<id_country xlink:href=\"\
         http://172.24.0.3/api/countries/8\"><![CDATA[8]]></id_country>\n\t<id_state><![CDATA[0]]></id_state>\n\
-        \t<alias><![CDATA[My address]]></alias>\n\t<company></company>\n\t<lastname><![CDATA[DOE]]></lastname>\n\
+        \t<alias><![CDATA[Mon adresse]]></alias>\n\t<company></company>\n\t<lastname><![CDATA[DOE]]></lastname>\n\
         \t<firstname><![CDATA[John]]></firstname>\n\t<vat_number></vat_number>\n\t\
         <address1><![CDATA[16, Main street]]></address1>\n\t<address2><![CDATA[2nd\
         \ floor]]></address2>\n\t<postcode><![CDATA[75002]]></postcode>\n\t<city><![CDATA[Paris]]></city>\n\

--- a/connector_prestashop/tests/fixtures/cassettes/test_import_partner_batch.yaml
+++ b/connector_prestashop/tests/fixtures/cassettes/test_import_partner_batch.yaml
@@ -60,8 +60,6 @@ interactions:
 
         <customer id="1" xlink:href="http://172.24.0.3/api/customers/1"/>
 
-        <customer id="2" xlink:href="http://172.24.0.3/api/customers/2"/>
-
         </customers>
 
         </prestashop>

--- a/connector_prestashop/tests/fixtures/cassettes/test_import_partner_category_record_1.yaml
+++ b/connector_prestashop/tests/fixtures/cassettes/test_import_partner_category_record_1.yaml
@@ -15,7 +15,7 @@ interactions:
         \t<show_prices><![CDATA[1]]></show_prices>\n\t<date_add><![CDATA[2016-09-02\
         \ 14:37:17]]></date_add>\n\t<date_upd><![CDATA[2016-09-06 15:03:01]]></date_upd>\n\
         \t<name><language id=\"1\" xlink:href=\"http://172.24.0.3/api/languages/1\"\
-        ><![CDATA[Customer A]]></language></name>\n</group>\n</prestashop>\n"}
+        ><![CDATA[Customer]]></language></name>\n</group>\n</prestashop>\n"}
     headers:
       access-time: ['1473766107']
       connection: [Keep-Alive]
@@ -49,7 +49,7 @@ interactions:
         \t<show_prices><![CDATA[1]]></show_prices>\n\t<date_add><![CDATA[2016-09-02\
         \ 14:37:17]]></date_add>\n\t<date_upd><![CDATA[2016-09-06 15:03:01]]></date_upd>\n\
         \t<name><language id=\"1\" xlink:href=\"http://172.24.0.3/api/languages/1\"\
-        ><![CDATA[Customer A]]></language></name>\n</group>\n</prestashop>\n"}
+        ><![CDATA[Customer]]></language></name>\n</group>\n</prestashop>\n"}
     headers:
       access-time: ['1473766107']
       connection: [Keep-Alive]

--- a/connector_prestashop/tests/fixtures/cassettes/test_import_sale_record_5.yaml
+++ b/connector_prestashop/tests/fixtures/cassettes/test_import_sale_record_5.yaml
@@ -82,6 +82,193 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.6.0 CPython/2.7.9 Linux/4.4.0-51-generic]
     method: GET
+    uri: http://172.22.0.4/api/orders/5
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <prestashop xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<order>\n\t<id><![CDATA[5]]></id>\n\
+        \t<id_address_delivery xlink:href=\"http://172.22.0.4/api/addresses/4\"><![CDATA[4]]></id_address_delivery>\n\
+        \t<id_address_invoice xlink:href=\"http://172.22.0.4/api/addresses/4\"><![CDATA[4]]></id_address_invoice>\n\
+        \t<id_cart xlink:href=\"http://172.22.0.4/api/carts/5\"><![CDATA[5]]></id_cart>\n\
+        \t<id_currency xlink:href=\"http://172.22.0.4/api/currencies/1\"><![CDATA[1]]></id_currency>\n\
+        \t<id_lang xlink:href=\"http://172.22.0.4/api/languages/1\"><![CDATA[1]]></id_lang>\n\
+        \t<id_customer xlink:href=\"http://172.22.0.4/api/customers/1\"><![CDATA[1]]></id_customer>\n\
+        \t<id_carrier xlink:href=\"http://172.22.0.4/api/carriers/2\"><![CDATA[2]]></id_carrier>\n\
+        \t<current_state xlink:href=\"http://172.22.0.4/api/order_states/10\"><![CDATA[10]]></current_state>\n\
+        \t<module><![CDATA[bankwire]]></module>\n\t<invoice_number><![CDATA[0]]></invoice_number>\n\
+        \t<invoice_date><![CDATA[0000-00-00 00:00:00]]></invoice_date>\n\t<delivery_number><![CDATA[0]]></delivery_number>\n\
+        \t<delivery_date><![CDATA[0000-00-00 00:00:00]]></delivery_date>\n\t<valid><![CDATA[0]]></valid>\n\
+        \t<date_add><![CDATA[2016-12-07 15:13:53]]></date_add>\n\t<date_upd><![CDATA[2016-12-07\
+        \ 15:13:53]]></date_upd>\n\t<shipping_number notFilterable=\"true\"></shipping_number>\n\
+        \t<id_shop_group><![CDATA[1]]></id_shop_group>\n\t<id_shop><![CDATA[1]]></id_shop>\n\
+        \t<secure_key><![CDATA[b44a6d9efd7a0076a0fbce6b15eaf3b1]]></secure_key>\n\t\
+        <payment><![CDATA[Bank wire]]></payment>\n\t<recyclable><![CDATA[0]]></recyclable>\n\
+        \t<gift><![CDATA[0]]></gift>\n\t<gift_message></gift_message>\n\t<mobile_theme><![CDATA[0]]></mobile_theme>\n\
+        \t<total_discounts><![CDATA[0.000000]]></total_discounts>\n\t<total_discounts_tax_incl><![CDATA[0.000000]]></total_discounts_tax_incl>\n\
+        \t<total_discounts_tax_excl><![CDATA[0.000000]]></total_discounts_tax_excl>\n\
+        \t<total_paid><![CDATA[71.510000]]></total_paid>\n\t<total_paid_tax_incl><![CDATA[71.510000]]></total_paid_tax_incl>\n\
+        \t<total_paid_tax_excl><![CDATA[71.510000]]></total_paid_tax_excl>\n\t<total_paid_real><![CDATA[0.000000]]></total_paid_real>\n\
+        \t<total_products><![CDATA[69.510000]]></total_products>\n\t<total_products_wt><![CDATA[69.510000]]></total_products_wt>\n\
+        \t<total_shipping><![CDATA[2.000000]]></total_shipping>\n\t<total_shipping_tax_incl><![CDATA[2.000000]]></total_shipping_tax_incl>\n\
+        \t<total_shipping_tax_excl><![CDATA[2.000000]]></total_shipping_tax_excl>\n\
+        \t<carrier_tax_rate><![CDATA[0.000]]></carrier_tax_rate>\n\t<total_wrapping><![CDATA[0.000000]]></total_wrapping>\n\
+        \t<total_wrapping_tax_incl><![CDATA[0.000000]]></total_wrapping_tax_incl>\n\
+        \t<total_wrapping_tax_excl><![CDATA[0.000000]]></total_wrapping_tax_excl>\n\
+        \t<round_mode><![CDATA[0]]></round_mode>\n\t<round_type><![CDATA[0]]></round_type>\n\
+        \t<conversion_rate><![CDATA[1.000000]]></conversion_rate>\n\t<reference><![CDATA[KHWLILZLL]]></reference>\n\
+        <associations>\n<order_rows nodeType=\"order_row\" virtualEntity=\"true\"\
+        >\n\t<order_row>\n\t<id><![CDATA[13]]></id>\n\t<product_id><![CDATA[1]]></product_id>\n\
+        \t<product_attribute_id><![CDATA[1]]></product_attribute_id>\n\t<product_quantity><![CDATA[1]]></product_quantity>\n\
+        \t<product_name><![CDATA[Faded Short Sleeve T-shirts - Color : Orange, Size\
+        \ : S]]></product_name>\n\t<product_reference><![CDATA[demo_1]]></product_reference>\n\
+        \t<product_ean13></product_ean13>\n\t<product_upc></product_upc>\n\t<product_price><![CDATA[16.510000]]></product_price>\n\
+        \t<unit_price_tax_incl><![CDATA[16.510000]]></unit_price_tax_incl>\n\t<unit_price_tax_excl><![CDATA[16.510000]]></unit_price_tax_excl>\n\
+        \t</order_row>\n\t<order_row>\n\t<id><![CDATA[14]]></id>\n\t<product_id><![CDATA[2]]></product_id>\n\
+        \t<product_attribute_id><![CDATA[7]]></product_attribute_id>\n\t<product_quantity><![CDATA[1]]></product_quantity>\n\
+        \t<product_name><![CDATA[Blouse - Color : Black, Size : S]]></product_name>\n\
+        \t<product_reference><![CDATA[demo_2]]></product_reference>\n\t<product_ean13></product_ean13>\n\
+        \t<product_upc></product_upc>\n\t<product_price><![CDATA[26.999852]]></product_price>\n\
+        \t<unit_price_tax_incl><![CDATA[27.000000]]></unit_price_tax_incl>\n\t<unit_price_tax_excl><![CDATA[27.000000]]></unit_price_tax_excl>\n\
+        \t</order_row>\n\t<order_row>\n\t<id><![CDATA[15]]></id>\n\t<product_id><![CDATA[3]]></product_id>\n\
+        \t<product_attribute_id><![CDATA[13]]></product_attribute_id>\n\t<product_quantity><![CDATA[1]]></product_quantity>\n\
+        \t<product_name><![CDATA[Printed Dress - Color : Orange, Size : S]]></product_name>\n\
+        \t<product_reference><![CDATA[demo_3]]></product_reference>\n\t<product_ean13></product_ean13>\n\
+        \t<product_upc></product_upc>\n\t<product_price><![CDATA[25.999852]]></product_price>\n\
+        \t<unit_price_tax_incl><![CDATA[26.000000]]></unit_price_tax_incl>\n\t<unit_price_tax_excl><![CDATA[26.000000]]></unit_price_tax_excl>\n\
+        \t</order_row>\n</order_rows>\n</associations>\n</order>\n</prestashop>\n"}
+    headers:
+      access-time: ['1481288293']
+      connection: [Keep-Alive]
+      content-length: ['4766']
+      content-sha1: [b0a5f9e0abd4472586374d8ebbb44c3f5fb262f3]
+      content-type: [text/xml;charset=utf-8]
+      date: ['Fri, 09 Dec 2016 12:58:13 GMT']
+      execution-time: ['0.003']
+      keep-alive: ['timeout=5, max=100']
+      psws-version: [1.6.1.9]
+      server: [Apache/2.4.10 (Debian)]
+      vary: [Accept-Encoding]
+      x-powered-by: [PrestaShop Webservice]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.6.0 CPython/2.7.9 Linux/4.4.0-51-generic]
+    method: GET
+    uri: http://172.22.0.4/api/order_payments?filter%5Border_reference%5D=KHWLILZLL
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
+
+        <prestashop xmlns:xlink="http://www.w3.org/1999/xlink">
+
+        <order_payments>
+
+        </order_payments>
+
+        </prestashop>
+
+        '}
+    headers:
+      access-time: ['1481288293']
+      connection: [Keep-Alive]
+      content-length: ['144']
+      content-sha1: [1e5e8b6f80106cd18c5dddd6e65ef612feb28673]
+      content-type: [text/xml;charset=utf-8]
+      date: ['Fri, 09 Dec 2016 12:58:13 GMT']
+      execution-time: ['0.002']
+      keep-alive: ['timeout=5, max=100']
+      psws-version: [1.6.1.9]
+      server: [Apache/2.4.10 (Debian)]
+      set-cookie: ['PrestaShop-095ca4fa56f569ddf56f692e2249251a=DYHr6QQHnOuI4%2BKs9hL5Tb45G5tfuoewgFOGXCa0zqjmkA9hhHGyvwxvbnN6cWseoA1XiyfSBRNxfbcRDI13Wayf7uzmWqLeeredNQhXw5U%3D000078;
+          expires=Thu, 29-Dec-2016 12:58:13 GMT; Max-Age=1728000; path=/; httponly']
+      vary: [Accept-Encoding]
+      x-powered-by: [PrestaShop Webservice]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.6.0 CPython/2.7.9 Linux/4.4.0-51-generic]
+    method: GET
+    uri: http://172.22.0.4/api/orders/5
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <prestashop xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<order>\n\t<id><![CDATA[5]]></id>\n\
+        \t<id_address_delivery xlink:href=\"http://172.22.0.4/api/addresses/4\"><![CDATA[4]]></id_address_delivery>\n\
+        \t<id_address_invoice xlink:href=\"http://172.22.0.4/api/addresses/4\"><![CDATA[4]]></id_address_invoice>\n\
+        \t<id_cart xlink:href=\"http://172.22.0.4/api/carts/5\"><![CDATA[5]]></id_cart>\n\
+        \t<id_currency xlink:href=\"http://172.22.0.4/api/currencies/1\"><![CDATA[1]]></id_currency>\n\
+        \t<id_lang xlink:href=\"http://172.22.0.4/api/languages/1\"><![CDATA[1]]></id_lang>\n\
+        \t<id_customer xlink:href=\"http://172.22.0.4/api/customers/1\"><![CDATA[1]]></id_customer>\n\
+        \t<id_carrier xlink:href=\"http://172.22.0.4/api/carriers/2\"><![CDATA[2]]></id_carrier>\n\
+        \t<current_state xlink:href=\"http://172.22.0.4/api/order_states/10\"><![CDATA[10]]></current_state>\n\
+        \t<module><![CDATA[bankwire]]></module>\n\t<invoice_number><![CDATA[0]]></invoice_number>\n\
+        \t<invoice_date><![CDATA[0000-00-00 00:00:00]]></invoice_date>\n\t<delivery_number><![CDATA[0]]></delivery_number>\n\
+        \t<delivery_date><![CDATA[0000-00-00 00:00:00]]></delivery_date>\n\t<valid><![CDATA[0]]></valid>\n\
+        \t<date_add><![CDATA[2016-12-07 15:13:53]]></date_add>\n\t<date_upd><![CDATA[2016-12-07\
+        \ 15:13:53]]></date_upd>\n\t<shipping_number notFilterable=\"true\"></shipping_number>\n\
+        \t<id_shop_group><![CDATA[1]]></id_shop_group>\n\t<id_shop><![CDATA[1]]></id_shop>\n\
+        \t<secure_key><![CDATA[b44a6d9efd7a0076a0fbce6b15eaf3b1]]></secure_key>\n\t\
+        <payment><![CDATA[Bank wire]]></payment>\n\t<recyclable><![CDATA[0]]></recyclable>\n\
+        \t<gift><![CDATA[0]]></gift>\n\t<gift_message></gift_message>\n\t<mobile_theme><![CDATA[0]]></mobile_theme>\n\
+        \t<total_discounts><![CDATA[0.000000]]></total_discounts>\n\t<total_discounts_tax_incl><![CDATA[0.000000]]></total_discounts_tax_incl>\n\
+        \t<total_discounts_tax_excl><![CDATA[0.000000]]></total_discounts_tax_excl>\n\
+        \t<total_paid><![CDATA[71.510000]]></total_paid>\n\t<total_paid_tax_incl><![CDATA[71.510000]]></total_paid_tax_incl>\n\
+        \t<total_paid_tax_excl><![CDATA[71.510000]]></total_paid_tax_excl>\n\t<total_paid_real><![CDATA[0.000000]]></total_paid_real>\n\
+        \t<total_products><![CDATA[69.510000]]></total_products>\n\t<total_products_wt><![CDATA[69.510000]]></total_products_wt>\n\
+        \t<total_shipping><![CDATA[2.000000]]></total_shipping>\n\t<total_shipping_tax_incl><![CDATA[2.000000]]></total_shipping_tax_incl>\n\
+        \t<total_shipping_tax_excl><![CDATA[2.000000]]></total_shipping_tax_excl>\n\
+        \t<carrier_tax_rate><![CDATA[0.000]]></carrier_tax_rate>\n\t<total_wrapping><![CDATA[0.000000]]></total_wrapping>\n\
+        \t<total_wrapping_tax_incl><![CDATA[0.000000]]></total_wrapping_tax_incl>\n\
+        \t<total_wrapping_tax_excl><![CDATA[0.000000]]></total_wrapping_tax_excl>\n\
+        \t<round_mode><![CDATA[0]]></round_mode>\n\t<round_type><![CDATA[0]]></round_type>\n\
+        \t<conversion_rate><![CDATA[1.000000]]></conversion_rate>\n\t<reference><![CDATA[KHWLILZLL]]></reference>\n\
+        <associations>\n<order_rows nodeType=\"order_row\" virtualEntity=\"true\"\
+        >\n\t<order_row>\n\t<id><![CDATA[13]]></id>\n\t<product_id><![CDATA[1]]></product_id>\n\
+        \t<product_attribute_id><![CDATA[1]]></product_attribute_id>\n\t<product_quantity><![CDATA[1]]></product_quantity>\n\
+        \t<product_name><![CDATA[Faded Short Sleeve T-shirts - Color : Orange, Size\
+        \ : S]]></product_name>\n\t<product_reference><![CDATA[demo_1]]></product_reference>\n\
+        \t<product_ean13></product_ean13>\n\t<product_upc></product_upc>\n\t<product_price><![CDATA[16.510000]]></product_price>\n\
+        \t<unit_price_tax_incl><![CDATA[16.510000]]></unit_price_tax_incl>\n\t<unit_price_tax_excl><![CDATA[16.510000]]></unit_price_tax_excl>\n\
+        \t</order_row>\n\t<order_row>\n\t<id><![CDATA[14]]></id>\n\t<product_id><![CDATA[2]]></product_id>\n\
+        \t<product_attribute_id><![CDATA[7]]></product_attribute_id>\n\t<product_quantity><![CDATA[1]]></product_quantity>\n\
+        \t<product_name><![CDATA[Blouse - Color : Black, Size : S]]></product_name>\n\
+        \t<product_reference><![CDATA[demo_2]]></product_reference>\n\t<product_ean13></product_ean13>\n\
+        \t<product_upc></product_upc>\n\t<product_price><![CDATA[26.999852]]></product_price>\n\
+        \t<unit_price_tax_incl><![CDATA[27.000000]]></unit_price_tax_incl>\n\t<unit_price_tax_excl><![CDATA[27.000000]]></unit_price_tax_excl>\n\
+        \t</order_row>\n\t<order_row>\n\t<id><![CDATA[15]]></id>\n\t<product_id><![CDATA[3]]></product_id>\n\
+        \t<product_attribute_id><![CDATA[13]]></product_attribute_id>\n\t<product_quantity><![CDATA[1]]></product_quantity>\n\
+        \t<product_name><![CDATA[Printed Dress - Color : Orange, Size : S]]></product_name>\n\
+        \t<product_reference><![CDATA[demo_3]]></product_reference>\n\t<product_ean13></product_ean13>\n\
+        \t<product_upc></product_upc>\n\t<product_price><![CDATA[25.999852]]></product_price>\n\
+        \t<unit_price_tax_incl><![CDATA[26.000000]]></unit_price_tax_incl>\n\t<unit_price_tax_excl><![CDATA[26.000000]]></unit_price_tax_excl>\n\
+        \t</order_row>\n</order_rows>\n</associations>\n</order>\n</prestashop>\n"}
+    headers:
+      access-time: ['1481288293']
+      connection: [Keep-Alive]
+      content-length: ['4766']
+      content-sha1: [b0a5f9e0abd4472586374d8ebbb44c3f5fb262f3]
+      content-type: [text/xml;charset=utf-8]
+      date: ['Fri, 09 Dec 2016 12:58:13 GMT']
+      execution-time: ['0.003']
+      keep-alive: ['timeout=5, max=100']
+      psws-version: [1.6.1.9]
+      server: [Apache/2.4.10 (Debian)]
+      vary: [Accept-Encoding]
+      x-powered-by: [PrestaShop Webservice]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.6.0 CPython/2.7.9 Linux/4.4.0-51-generic]
+    method: GET
     uri: http://172.22.0.4/api/order_payments?filter%5Border_reference%5D=KHWLILZLL
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>

--- a/connector_prestashop/tests/test_export_stock_qty_job.py
+++ b/connector_prestashop/tests/test_export_stock_qty_job.py
@@ -17,9 +17,9 @@ class TestExportStockQuantity(ExportStockQuantityCase):
     def test_job_export_qty(self):
         """ Export a qty on PrestaShop """
         variant_binding = self._create_product_binding(
-            name='Faded Short Sleeves T-shirt',
-            template_ps_id=1,
-            variant_ps_id=1,
+            name='Blouse',
+            template_ps_id=2,
+            variant_ps_id=7,
         )
         base_qty = variant_binding.qty_available
         base_prestashop_qty = variant_binding.quantity
@@ -41,13 +41,13 @@ class TestExportStockQuantity(ExportStockQuantityCase):
             self.assertEqual('GET', request.method)
             self.assertEqual('/api/stock_availables',
                              self.parse_path(request.uri))
-            expected_query = {'filter[id_product]': ['1'],
+            expected_query = {'filter[id_product]': ['2'],
                               'filter[id_product_attribute]': ['0']}
             self.assertDictEqual(expected_query, self.parse_qs(request.uri))
 
             request = cassette.requests[1]
             self.assertEqual('GET', request.method)
-            self.assertEqual('/api/stock_availables/1',
+            self.assertEqual('/api/stock_availables/2',
                              self.parse_path(request.uri))
             self.assertDictEqual({}, self.parse_qs(request.uri))
 
@@ -59,12 +59,12 @@ class TestExportStockQuantity(ExportStockQuantityCase):
 
             self.assertTrue(
                 set({'depends_on_stock': '0',
-                     'id': '1',
-                     'id_product': '1',
+                     'id': '2',
+                     'id_product': '2',
                      'id_product_attribute': '0',
                      'id_shop': '1',
                      'id_shop_group': '0',
-                     'out_of_stock': '2',
+                     'out_of_stock': '0',
                      'quantity': '0'}.items())
                 .issubset(set(body['prestashop']['stock_available'].items())))
             self.assertDictEqual({}, self.parse_qs(request.uri))

--- a/connector_prestashop/tests/test_import_partner.py
+++ b/connector_prestashop/tests/test_import_partner.py
@@ -88,7 +88,7 @@ class TestImportPartner(PrestashopTransactionCase):
             self.assertDictEqual(expected_query, self.parse_qs(request.uri))
 
             delay_record_instance = delay_record_mock.return_value
-            self.assertEqual(5, delay_record_instance.import_record.call_count)
+            self.assertEqual(4, delay_record_instance.import_record.call_count)
 
     @assert_no_job_delayed
     def test_import_partner_category_record(self):
@@ -104,7 +104,7 @@ class TestImportPartner(PrestashopTransactionCase):
 
         expected = [
             ExpectedCategory(
-                name='Customer A',
+                name='Customer',
             )]
 
         self.assert_records(expected, category_bindings)
@@ -201,7 +201,7 @@ class TestImportPartner(PrestashopTransactionCase):
 
         expected = [
             ExpectedAddress(
-                name='John DOE (My address)',
+                name='John DOE (Mon adresse)',
                 parent_id=partner,
                 street='16, Main street',
                 street2='2nd floor',


### PR DESCRIPTION
Hi,

connector_prestashop pass the tests with VCR recorded requests but not with new requests to a Prestashop available.

Here tests are fixed to pass them with a fresh Prestashop.

Regards!

cc @PlanetaTIC