### PR TITLE
[FIX] [10.0] connector_prestashop: Fix no JPG images

### DIFF
--- a/connector_prestashop/components/backend_adapter.py
+++ b/connector_prestashop/components/backend_adapter.py
@@ -81,10 +81,7 @@ class PrestaShopWebServiceImage(PrestaShopWebServiceDict):
     def get_image_public_url(self, record):
         url = self._api_url.replace('/api', '')
         url += '/img/p/' + '/'.join(list(record['id_image']))
-        extension = ''
-        if record['type'] == 'image/jpeg':
-            extension = '.jpg'
-        url += '/' + record['id_image'] + extension
+        url += '/%s.jpg' % record['id_image']
         return url
 
 

--- a/connector_prestashop/models/product_image/importer.py
+++ b/connector_prestashop/models/product_image/importer.py
@@ -5,7 +5,6 @@
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import mapping
 
-import mimetypes
 import logging
 
 from odoo import _

--- a/connector_prestashop/models/product_image/importer.py
+++ b/connector_prestashop/models/product_image/importer.py
@@ -41,7 +41,7 @@ class ProductImageMapper(Component):
 
     @mapping
     def extension(self, record):
-        return {'extension': mimetypes.guess_extension(record['type'])}
+        return {'extension': '.jpg'}
 
     @mapping
     def image_url(self, record):


### PR DESCRIPTION
The extension of a PS image is JPG regardless of its `content-type`

cc @PlanetaTIC