### PR TITLE
[FIX] connector_prestashop: Override external dependencies to match PyPi

### DIFF
--- a/setup/connector_prestashop/setup.py
+++ b/setup/connector_prestashop/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'vcr': 'vcrpy==1.10.5',
+            },
+        },
+    },
 )


### PR DESCRIPTION
Closes #113 

cc @Tecnativa