### PR TITLE
[10.0] [FIX] connector_prestashop: Fix tax included product price

### DIFF
--- a/connector_prestashop/models/product_product/importer.py
+++ b/connector_prestashop/models/product_product/importer.py
@@ -219,15 +219,10 @@ class ProductCombinationMapper(Component):
         return tax_group.tax_ids
 
     def _apply_taxes(self, tax, price):
-        if self.backend_record.taxes_included == tax.price_include:
-            return price
-        factor_tax = tax.price_include and (1 + tax.amount / 100) or 1.0
-        if self.backend_record.taxes_included:
-            if not tax.price_include:
-                return price / factor_tax
-        else:
-            if tax.price_include:
-                return price * factor_tax
+        if tax.price_include:
+            factor_tax = tax.price_include and (1 + tax.amount / 100) or 1.0
+            return price * factor_tax
+        return price
 
     @mapping
     def specific_price(self, record):

--- a/connector_prestashop/models/product_template/importer.py
+++ b/connector_prestashop/models/product_template/importer.py
@@ -54,15 +54,10 @@ class TemplateMapper(Component):
     ]
 
     def _apply_taxes(self, tax, price):
-        if self.backend_record.taxes_included == tax.price_include:
-            return price
-        factor_tax = tax.price_include and (1 + tax.amount / 100) or 1.0
-        if self.backend_record.taxes_included:
-            if not tax.price_include:
-                return price / factor_tax
-        else:
-            if tax.price_include:
-                return price * factor_tax
+        if tax.price_include:
+            factor_tax = tax.price_include and (1 + tax.amount / 100) or 1.0
+            return price * factor_tax
+        return price
 
     @mapping
     def list_price(self, record):


### PR DESCRIPTION
Import the product prices with or without taxes according to the field included price of the tax in Odoo.

PS product price is always tax excluded.

Field taxes included of PS backend is used to choose between tax excluded/included price of PS lines on import order.

cc @PlanetaTIC