### PR TITLE
[10.0] [FIX] connector_prestashop: fix description_html translations

### DIFF
--- a/connector_prestashop/models/product_template/common.py
+++ b/connector_prestashop/models/product_template/common.py
@@ -80,11 +80,13 @@ class PrestashopProductTemplate(models.Model):
     description_html = fields.Html(
         string='Description',
         translate=True,
+        sanitize=False,
         help="HTML description from PrestaShop",
     )
     description_short_html = fields.Html(
         string='Short Description',
         translate=True,
+        sanitize=False,
     )
     date_add = fields.Datetime(
         string='Created at (in PrestaShop)',


### PR DESCRIPTION
On model prestashop.product.template, translation of description_html and description_short_html fields didn't work. Set parameter sanitize=False on its field definition to get translations working properly.

cc @PlanetaTIC