### PR TITLE
[10.0] [FIX] connector_prestashop: Fix 100% discount error on import sale line

### DIFF
--- a/connector_prestashop/models/sale_order/importer.py
+++ b/connector_prestashop/models/sale_order/importer.py
@@ -412,8 +412,12 @@ class SaleOrderLineMapper(Component):
             key = 'unit_price_tax_excl'
         if record['reduction_percent']:
             reduction = Decimal(record['reduction_percent'])
+            reduction = (100 - reduction) / 100
             price = Decimal(record[key])
-            price_unit = price / ((100 - reduction) / 100)
+            if reduction:
+                price_unit = price / reduction
+            else:
+                price_unit = 0
         else:
             price_unit = record[key]
         return {'price_unit': price_unit}


### PR DESCRIPTION
Fix zero division error on import a sale line with 100% discount:

> 2019-10-17 20:00:13,209 14580 ERROR db odoo.addons.queue_job.controllers.main: Traceback (most recent call last):
>   File "../queue_job/controllers/main.py", line 104, in runjob
>     self._try_perform_job(env, job)
>   File "../queue_job/controllers/main.py", line 62, in _try_perform_job
>     job.perform()
>   File "../queue_job/job.py", line 467, in perform
>     self.result = self.func(*tuple(self.args), **self.kwargs)
>   File "../connector_prestashop/models/binding/common.py", line 47, in import_record
>     return importer.run(prestashop_id, force=force)
>   File "../connector_prestashop/components/importer.py", line 272, in run
>     self._import(binding, **kwargs)
>   File "../connector_prestashop/components/importer.py", line 287, in _import
>     record = self._create_data(map_record)
>   File "../connector_prestashop/components/importer.py", line 125, in _create_data
>     return map_record.values(for_create=True)
>   File "../connector/components/mapper.py", line 979, in values
>     values = self._mapper._apply(self, options=options)
>   File "../connector/components/mapper.py", line 753, in _apply
>     return self._apply_with_options(map_record)
>   File "../connector/components/mapper.py", line 802, in _apply_with_options
>     to_attr, model_name)
>   File "../connector_prestashop/models/sale_order/importer.py", line 200, in _map_child
>     [detail_record], map_record, to_attr, options=self.options
>   File "../connector/components/mapper.py", line 349, in get_items
>     item_values = self.get_item_values(map_record, to_attr, options)
>   File "../connector/components/mapper.py", line 372, in get_item_values
>     return map_record.values(**options)
>   File "../connector/components/mapper.py", line 979, in values
>     values = self._mapper._apply(self, options=options)
>   File "../connector/components/mapper.py", line 753, in _apply
>     return self._apply_with_options(map_record)
>   File "../connector/components/mapper.py", line 791, in _apply_with_options
>     values = meth(map_record.source)
>   File "../connector_prestashop/models/sale_order/importer.py", line 484, in price_unit
>     price_unit = price / ((100 - reduction) / 100)
>   File "/usr/lib/python2.7/decimal.py", line 1321, in __truediv__
>     return context._raise_error(DivisionUndefined, '0 / 0')
>   File "/usr/lib/python2.7/decimal.py", line 3873, in _raise_error
>     raise error(explanation)
> InvalidOperation: 0 / 0

cc @PlanetaTIC