### PR TITLE
[10.0] [FIX] connector_prestashop: boolean fields importation

### DIFF
--- a/connector_prestashop/README.rst
+++ b/connector_prestashop/README.rst
@@ -156,6 +156,7 @@ Contributors
 * Simone Orsi <simone.orsi@camptocamp.com>
 * Florent THOMAS <florent.thomas@mind-and-go.com>
 * Francisco Fernández <ffernandez@planetatic.com>
+* Marc Poch <mpoch@planetatic.com>
 
 Maintainer
 ----------

--- a/connector_prestashop/components/mapper.py
+++ b/connector_prestashop/components/mapper.py
@@ -20,7 +20,7 @@ def external_to_bool(field, binding=None):
             return False
         ext_bool = record[field]
         if isinstance(ext_bool, bool):
-            result = record
+            result = ext_bool
         else:
             result = True
             if ext_bool == '0':

--- a/connector_prestashop/components/mapper.py
+++ b/connector_prestashop/components/mapper.py
@@ -5,6 +5,30 @@ from odoo.addons.component.core import AbstractComponent
 from odoo.addons.connector.components.mapper import mapping
 
 
+def external_to_bool(field, binding=None):
+    """ A modifier intended to be used on the ``direct`` mappings.
+
+    For a field from a backend which is a boolean, convert the Prestashop
+    value ('0' or '1') to python boolean.
+
+    Example::
+        direct = [(external_to_bool('available_for_order')), 'available_for_order']
+    :param field: name of the source field in the record
+    """
+    def modifier(self, record, to_attr):
+        if not record[field]:
+            return False
+        ext_bool = record[field]
+        if isinstance(ext_bool, bool):
+            result = record
+        else:
+            result = True
+            if ext_bool == '0':
+                result = False
+        return result
+    return modifier
+
+
 class PrestashopImportMapper(AbstractComponent):
     _name = 'prestashop.import.mapper'
     _inherit = ['base.prestashop.connector', 'base.import.mapper']

--- a/connector_prestashop/models/product_category/importer.py
+++ b/connector_prestashop/models/product_category/importer.py
@@ -5,6 +5,7 @@ from odoo import _
 
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import mapping, external_to_m2o
+from odoo.addons.connector_prestashop.components.mapper import external_to_bool
 
 import datetime
 import logging
@@ -29,7 +30,7 @@ class ProductCategoryMapper(Component):
         ('meta_keywords', 'meta_keywords'),
         ('meta_title', 'meta_title'),
         (external_to_m2o('id_shop_default'), 'default_shop_id'),
-        ('active', 'active'),
+        (external_to_bool('active'), 'active'),
         ('position', 'position')
     ]
 

--- a/connector_prestashop/models/product_supplierinfo/importer.py
+++ b/connector_prestashop/models/product_supplierinfo/importer.py
@@ -4,6 +4,7 @@
 from odoo.addons.queue_job.exception import FailedJobError
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import mapping
+from odoo.addons.connector_prestashop.components.mapper import external_to_bool
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ class SupplierMapper(Component):
     direct = [
         ('name', 'name'),
         ('id', 'prestashop_id'),
-        ('active', 'active'),
+        (external_to_bool('active'), 'active'),
     ]
 
     @mapping

--- a/connector_prestashop/models/product_template/importer.py
+++ b/connector_prestashop/models/product_template/importer.py
@@ -14,6 +14,7 @@ from odoo.addons.queue_job.job import job
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import (
     mapping, external_to_m2o, only_create)
+from odoo.addons.connector_prestashop.components.mapper import external_to_bool
 from odoo.exceptions import ValidationError
 
 
@@ -49,8 +50,8 @@ class TemplateMapper(Component):
         (external_to_m2o('id_shop_default'), 'default_shop_id'),
         ('link_rewrite', 'link_rewrite'),
         ('reference', 'reference'),
-        ('available_for_order', 'available_for_order'),
-        ('on_sale', 'on_sale'),
+        (external_to_bool('available_for_order'), 'available_for_order'),
+        (external_to_bool('on_sale'), 'on_sale'),
     ]
 
     def _apply_taxes(self, tax, price):

--- a/connector_prestashop/models/res_partner/importer.py
+++ b/connector_prestashop/models/res_partner/importer.py
@@ -9,6 +9,7 @@ from odoo import _
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import (
     mapping, external_to_m2o, only_create)
+from odoo.addons.connector_prestashop.components.mapper import external_to_bool
 
 
 class PartnerImportMapper(Component):
@@ -22,7 +23,7 @@ class PartnerImportMapper(Component):
         ('email', 'email'),
         ('newsletter', 'newsletter'),
         ('company', 'company'),
-        ('active', 'active'),
+        (external_to_bool('active'), 'active'),
         ('note', 'comment'),
         (external_to_m2o('id_shop_group'), 'shop_group_id'),
         (external_to_m2o('id_shop'), 'shop_id'),


### PR DESCRIPTION
When importing instances from Prestashop, boolean fields are imported as string values: '0' for False, '1' for True. Converting these strings directly to boolean makes Python to interpret them always as True.

Fixed this issue to convert '0' to False.

cc @PlanetaTIC