### PR TITLE
[FIX] freeze version of freezegun

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ prestapyt >= 0.9.0
 unidecode
 bs4
 # tests dependencies
-freezegun
+freezegun==0.3.12
 vcrpy


### PR DESCRIPTION
Later versions cause a crash at installation time
with obscure message:

 'module' object has no attribute 'UTC'