### PR TITLE
[POC][14.0] Reintroduce partner matching

### DIFF
--- a/connector_prestashop/__manifest__.py
+++ b/connector_prestashop/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "PrestaShop-Odoo connector",
-    "version": "14.0.1.0.0",
+    "version": "14.0.2.0.0",
     "license": "AGPL-3",
     "depends": [
         "account",

--- a/connector_prestashop/migrations/14.0.2.0.0/pre-migrate.py
+++ b/connector_prestashop/migrations/14.0.2.0.0/pre-migrate.py
@@ -1,0 +1,18 @@
+# © 2022 Comunitea
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+            SELECT rel.relname, con.conname
+            FROM pg_catalog.pg_constraint con
+            INNER JOIN pg_catalog.pg_class rel
+                ON rel.oid = con.conrelid
+            INNER JOIN pg_catalog.pg_namespace nsp
+                ON nsp.oid = connamespace
+            WHERE con.conname ilike '%prestashop_erp_uniq%';
+        """
+    )
+    for constraint in cr.fetchall():
+        cr.execute(f"ALTER TABLE {constraint[0]} DROP CONSTRAINT {constraint[1]}")

--- a/connector_prestashop/models/binding/common.py
+++ b/connector_prestashop/models/binding/common.py
@@ -96,11 +96,3 @@ class PrestashopBindingOdoo(models.AbstractModel):
         string="Odoo binding",
         selection=_get_selection,
     )
-
-    _sql_constraints = [
-        (
-            "prestashop_erp_uniq",
-            "unique(backend_id, odoo_id)",
-            "An ERP record with same ID already exists on PrestaShop.",
-        ),
-    ]

--- a/connector_prestashop/models/prestashop_backend/common.py
+++ b/connector_prestashop/models/prestashop_backend/common.py
@@ -145,9 +145,10 @@ class PrestashopBackend(models.Model):
         help="The selected fields will be matched to the ref field of the "
         "partner. Please adapt your datas consequently.",
     )
-    # matching_customer_ch = fields.Many2one(
-    #     comodel_name='prestashop.partner.field', string="Matched field",
-    #     help="Field that will be matched.")
+    matching_customer_ch = fields.Selection(
+        [("email", "Email"), ("vat", "Vat")], string="Matching Field for customer"
+    )
+
     tz = fields.Selection(
         _tz_get,
         "Timezone",
@@ -191,41 +192,6 @@ class PrestashopBackend(models.Model):
                             "install the module stock_available_unreserved."
                         )
                     )
-
-    @api.onchange("matching_customer")
-    def change_matching_customer(self):
-        # Update the field list so that if you API change you could find the
-        # new fields to map
-        if self._origin.id:
-            self.fill_matched_fields(self._origin.id)
-
-    def fill_matched_fields(self, backend_id):
-        self.ensure_one()
-
-        # options = {'limit': 1, 'display': 'full'}
-        # TODO : Unse new adapter pattern to get a simple partner json
-
-    #         prestashop = PrestaShopLocation(
-    #                         self.location.encode(),
-    #                         self.webservice_key,
-    #                     )
-    #
-    #         client = PrestaShopWebServiceDict(
-    #                     prestashop.api_url,
-    #                     prestashop.webservice_key)
-    #
-    #         customer = client.get('customers', options=options)
-    #         tab=customer['customers']['customer'].keys()
-    #         for key in tab:
-    #             key_present = self.env['prestashop.partner.field'].search(
-    #                     [('value', '=', key), ('backend_id', '=', backend_id)])
-    #
-    #             if len(key_present) == 0 :
-    #                 self.env['prestashop.partner.field'].create({
-    #                     'name' : key,
-    #                     'value' : key,
-    #                     'backend_id': backend_id
-    #                 })
 
     @api.model
     def _default_pricelist_id(self):

--- a/connector_prestashop/views/prestashop_backend_view.xml
+++ b/connector_prestashop/views/prestashop_backend_view.xml
@@ -302,6 +302,11 @@
                                 </group>
                                 <group string="Matching option for partner">
                                     <field name="matching_customer" />
+                                    <field
+                                        name="matching_customer_ch"
+                                        attrs="{'invisible':[('matching_customer', '=', False)],
+                                                    'required':[('matching_customer', '=', True)]}"
+                                    />
 
                                 </group>
                             </group>


### PR DESCRIPTION
There is a matching_customer field since old versions without functionality. I am working on allow match by vat or email, but to make this change work, it's necessary to remove the sql_contraint prestashop_erp_uniq, because a partner could be duplicated on prestashop.
I don't see why this constraint is needed, if you don't configure the match, never will be necesarry, and if you want to match them, then you will prefeer to keep 2 prestashop records binded with an odoo record.
Or we can keep the constraint in particular models, but it's not necessary in all bindings.
What do you think?