### PR TITLE
[IMP]Force partner type when PS company not set

### DIFF
--- a/connector_prestashop/models/res_partner/importer.py
+++ b/connector_prestashop/models/res_partner/importer.py
@@ -44,7 +44,7 @@ class PartnerImportMapper(Component):
     def is_company(self, record):
         if record.get("company"):
             return {"is_company": True}
-        return {}
+        return {"is_company": False}
 
     @mapping
     def birthday(self, record):


### PR DESCRIPTION
the company field in PS clearly indicates that it shoudl be a company in Odoo.
As a counterpart we should consider that if this field is not field, the PS account is a person.
This PR propose to force this value so that the general conf/behaviour in Odoo will not be the default behaviour for the connector.