### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/connector_prestashop_catalog_manager/__manifest__.py
+++ b/connector_prestashop_catalog_manager/__manifest__.py
@@ -15,7 +15,7 @@
     "author": "Akretion,"
               "AvanzOSC,"
               "Tecnativa,"
-              'Camptocamp SA,'
+              'Camptocamp,'
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/connector-prestashop",
     "category": "Connector",

--- a/connector_prestashop_manufacturer/__manifest__.py
+++ b/connector_prestashop_manufacturer/__manifest__.py
@@ -8,7 +8,7 @@
     'category': 'Connector',
     'website': 'https://odoo-community.org/',
     'author': 'Tecnativa, '
-              'Camptocamp SA '
+              'Camptocamp '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'application': False,


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.